### PR TITLE
Use global namespace

### DIFF
--- a/Sut.Generator.Tests/Snapshots/Verification.Test_index=1#Test1.g.verified.cs
+++ b/Sut.Generator.Tests/Snapshots/Verification.Test_index=1#Test1.g.verified.cs
@@ -11,12 +11,12 @@ public partial class Test1 {
   private Builder Sut { get; } = new();
 
   private class Builder {
-    public Microsoft.Extensions.Options.IOptions<TestOptions>? Options { get; private set; }
+    public global::Microsoft.Extensions.Options.IOptions<TestOptions>? Options { get; private set; }
 
     public Builder With_Options(
       TestOptions options
     ) {
-      Options = Microsoft.Extensions.Options.Options.Create(options);
+      Options = global::Microsoft.Extensions.Options.Options.Create(options);
       return this;
     }
 

--- a/Sut.Generator.Tests/Snapshots/Verification.Test_index=10#Test10.g.verified.cs
+++ b/Sut.Generator.Tests/Snapshots/Verification.Test_index=10#Test10.g.verified.cs
@@ -14,13 +14,13 @@ public partial class Test10 {
     public Mock<IDependency7> Dependency7 { get; } = new();
 
     public Builder With_Dependency7_Get(
-      System.Linq.Expressions.Expression<System.Func<System.Int32[], System.Boolean>> ids,
+      global::System.Linq.Expressions.Expression<global::System.Func<global::System.Int32[], global::System.Boolean>> ids,
       Command returns
     ) {
       Dependency7
         .Setup(x =>
           x.Get(
-            It.Is<System.Int32[]>(ids)
+            It.Is<global::System.Int32[]>(ids)
           )
         )
         .ReturnsAsync(returns)
@@ -29,13 +29,13 @@ public partial class Test10 {
     }
 
     public Builder With_Dependency7_Get_Exception(
-      System.Linq.Expressions.Expression<System.Func<System.Int32[], System.Boolean>> ids,
-      System.Exception exception
+      global::System.Linq.Expressions.Expression<global::System.Func<global::System.Int32[], global::System.Boolean>> ids,
+      global::System.Exception exception
     ) {
       Dependency7
         .Setup(x =>
           x.Get(
-            It.Is<System.Int32[]>(ids)
+            It.Is<global::System.Int32[]>(ids)
           )
         )
         .ThrowsAsync(exception);

--- a/Sut.Generator.Tests/Snapshots/Verification.Test_index=11#Test11.g.verified.cs
+++ b/Sut.Generator.Tests/Snapshots/Verification.Test_index=11#Test11.g.verified.cs
@@ -14,8 +14,8 @@ public partial class Test11 {
     public Mock<IDependency8<Command>> Dependency8 { get; } = new();
 
     public Builder With_Dependency8_Get(
-      System.Linq.Expressions.Expression<System.Func<Command, System.Boolean>> input,
-      System.Nullable<Command> returns
+      global::System.Linq.Expressions.Expression<global::System.Func<Command, global::System.Boolean>> input,
+      global::System.Nullable<Command> returns
     ) {
       Dependency8
         .Setup(x =>
@@ -29,8 +29,8 @@ public partial class Test11 {
     }
 
     public Builder With_Dependency8_Get_Exception(
-      System.Linq.Expressions.Expression<System.Func<Command, System.Boolean>> input,
-      System.Exception exception
+      global::System.Linq.Expressions.Expression<global::System.Func<Command, global::System.Boolean>> input,
+      global::System.Exception exception
     ) {
       Dependency8
         .Setup(x =>

--- a/Sut.Generator.Tests/Snapshots/Verification.Test_index=2#Test2.g.verified.cs
+++ b/Sut.Generator.Tests/Snapshots/Verification.Test_index=2#Test2.g.verified.cs
@@ -11,21 +11,21 @@ public partial class Test2 {
   private Builder Sut { get; } = new();
 
   private class Builder {
-    public Mock<Microsoft.Extensions.Logging.ILogger<Example2>> Logger { get; } = new();
+    public Mock<global::Microsoft.Extensions.Logging.ILogger<Example2>> Logger { get; } = new();
 
     public Builder With_Logger(
-      Microsoft.Extensions.Logging.LogLevel logLevel,
+      global::Microsoft.Extensions.Logging.LogLevel logLevel,
       string message,
-      System.Exception? exception = null
+      global::System.Exception? exception = null
     ) {
       Logger
         .Setup(x =>
           x.Log(
-            It.Is<Microsoft.Extensions.Logging.LogLevel>(l => l == logLevel),
-            It.IsAny<Microsoft.Extensions.Logging.EventId>(),
+            It.Is<global::Microsoft.Extensions.Logging.LogLevel>(l => l == logLevel),
+            It.IsAny<global::Microsoft.Extensions.Logging.EventId>(),
             It.Is<It.IsAnyType>((v, t) => v.ToString() == message),
-            It.Is<System.Exception?>(e => e == exception),
-            It.IsAny<System.Func<It.IsAnyType, System.Exception?, string>>()
+            It.Is<global::System.Exception?>(e => e == exception),
+            It.IsAny<global::System.Func<It.IsAnyType, global::System.Exception?, string>>()
           )
         )
         .Verifiable();

--- a/Sut.Generator.Tests/Snapshots/Verification.Test_index=3#Test3.g.verified.cs
+++ b/Sut.Generator.Tests/Snapshots/Verification.Test_index=3#Test3.g.verified.cs
@@ -11,8 +11,8 @@ public partial class Test3 {
   private Builder Sut { get; } = new();
 
   private class Builder {
-    public Microsoft.Extensions.Options.IOptions<TestOptions>? Options { get; private set; }
-    public Mock<Microsoft.Extensions.Logging.ILogger<Example3>> Logger { get; } = new();
+    public global::Microsoft.Extensions.Options.IOptions<TestOptions>? Options { get; private set; }
+    public Mock<global::Microsoft.Extensions.Logging.ILogger<Example3>> Logger { get; } = new();
     public Mock<IDependency1> Dependency1 { get; } = new();
     public Mock<IDependency3> Dependency3 { get; } = new();
     public Mock<Dependency4> Dependency4 { get; } = new();
@@ -22,23 +22,23 @@ public partial class Test3 {
     public Builder With_Options(
       TestOptions options
     ) {
-      Options = Microsoft.Extensions.Options.Options.Create(options);
+      Options = global::Microsoft.Extensions.Options.Options.Create(options);
       return this;
     }
 
     public Builder With_Logger(
-      Microsoft.Extensions.Logging.LogLevel logLevel,
+      global::Microsoft.Extensions.Logging.LogLevel logLevel,
       string message,
-      System.Exception? exception = null
+      global::System.Exception? exception = null
     ) {
       Logger
         .Setup(x =>
           x.Log(
-            It.Is<Microsoft.Extensions.Logging.LogLevel>(l => l == logLevel),
-            It.IsAny<Microsoft.Extensions.Logging.EventId>(),
+            It.Is<global::Microsoft.Extensions.Logging.LogLevel>(l => l == logLevel),
+            It.IsAny<global::Microsoft.Extensions.Logging.EventId>(),
             It.Is<It.IsAnyType>((v, t) => v.ToString() == message),
-            It.Is<System.Exception?>(e => e == exception),
-            It.IsAny<System.Func<It.IsAnyType, System.Exception?, string>>()
+            It.Is<global::System.Exception?>(e => e == exception),
+            It.IsAny<global::System.Func<It.IsAnyType, global::System.Exception?, string>>()
           )
         )
         .Verifiable();
@@ -46,13 +46,13 @@ public partial class Test3 {
     }
 
     public Builder With_Dependency1_Get(
-      System.Linq.Expressions.Expression<System.Func<System.Int32, System.Boolean>> id,
+      global::System.Linq.Expressions.Expression<global::System.Func<global::System.Int32, global::System.Boolean>> id,
       Command returns
     ) {
       Dependency1
         .Setup(x =>
           x.Get(
-            It.Is<System.Int32>(id)
+            It.Is<global::System.Int32>(id)
           )
         )
         .ReturnsAsync(returns)
@@ -61,13 +61,13 @@ public partial class Test3 {
     }
 
     public Builder With_Dependency1_Get_Exception(
-      System.Linq.Expressions.Expression<System.Func<System.Int32, System.Boolean>> id,
-      System.Exception exception
+      global::System.Linq.Expressions.Expression<global::System.Func<global::System.Int32, global::System.Boolean>> id,
+      global::System.Exception exception
     ) {
       Dependency1
         .Setup(x =>
           x.Get(
-            It.Is<System.Int32>(id)
+            It.Is<global::System.Int32>(id)
           )
         )
         .ThrowsAsync(exception);
@@ -75,7 +75,7 @@ public partial class Test3 {
     }
 
     public Builder With_Dependency3_Run(
-      System.Linq.Expressions.Expression<System.Func<Command, System.Boolean>> command
+      global::System.Linq.Expressions.Expression<global::System.Func<Command, global::System.Boolean>> command
     ) {
       Dependency3
         .Setup(x =>
@@ -88,8 +88,8 @@ public partial class Test3 {
     }
 
     public Builder With_Dependency3_Run_Exception(
-      System.Linq.Expressions.Expression<System.Func<Command, System.Boolean>> command,
-      System.Exception exception
+      global::System.Linq.Expressions.Expression<global::System.Func<Command, global::System.Boolean>> command,
+      global::System.Exception exception
     ) {
       Dependency3
         .Setup(x =>
@@ -112,7 +112,7 @@ public partial class Test3 {
     }
 
     public Builder With_Dependency4_Status(
-      System.Action<Dependency4> status
+      global::System.Action<Dependency4> status
     ) {
       Dependency4
         .SetupSet(status)
@@ -121,7 +121,7 @@ public partial class Test3 {
     }
 
     public Builder With_Dependency5_Update<T>(
-      System.Linq.Expressions.Expression<System.Func<T, System.Boolean>> input,
+      global::System.Linq.Expressions.Expression<global::System.Func<T, global::System.Boolean>> input,
       T returns
     ) {
       Dependency5
@@ -136,8 +136,8 @@ public partial class Test3 {
     }
 
     public Builder With_Dependency5_Update_Exception<T>(
-      System.Linq.Expressions.Expression<System.Func<T, System.Boolean>> input,
-      System.Exception exception
+      global::System.Linq.Expressions.Expression<global::System.Func<T, global::System.Boolean>> input,
+      global::System.Exception exception
     ) {
       Dependency5
         .Setup(x =>
@@ -150,15 +150,15 @@ public partial class Test3 {
     }
 
     public Builder With_Dependency6_Evaluate(
-      System.Linq.Expressions.Expression<System.Func<System.Func<Command, System.Boolean>, System.Boolean>> predicate,
-      System.Linq.Expressions.Expression<System.Func<System.Threading.CancellationToken, System.Boolean>> cancellationToken,
-      System.Boolean returns
+      global::System.Linq.Expressions.Expression<global::System.Func<global::System.Func<Command, global::System.Boolean>, global::System.Boolean>> predicate,
+      global::System.Linq.Expressions.Expression<global::System.Func<global::System.Threading.CancellationToken, global::System.Boolean>> cancellationToken,
+      global::System.Boolean returns
     ) {
       Dependency6
         .Setup(x =>
           x.Evaluate(
-            It.Is<System.Func<Command, System.Boolean>>(predicate),
-            It.Is<System.Threading.CancellationToken>(cancellationToken)
+            It.Is<global::System.Func<Command, global::System.Boolean>>(predicate),
+            It.Is<global::System.Threading.CancellationToken>(cancellationToken)
           )
         )
         .Returns(returns)
@@ -167,15 +167,15 @@ public partial class Test3 {
     }
 
     public Builder With_Dependency6_Evaluate_Exception(
-      System.Linq.Expressions.Expression<System.Func<System.Func<Command, System.Boolean>, System.Boolean>> predicate,
-      System.Linq.Expressions.Expression<System.Func<System.Threading.CancellationToken, System.Boolean>> cancellationToken,
-      System.Exception exception
+      global::System.Linq.Expressions.Expression<global::System.Func<global::System.Func<Command, global::System.Boolean>, global::System.Boolean>> predicate,
+      global::System.Linq.Expressions.Expression<global::System.Func<global::System.Threading.CancellationToken, global::System.Boolean>> cancellationToken,
+      global::System.Exception exception
     ) {
       Dependency6
         .Setup(x =>
           x.Evaluate(
-            It.Is<System.Func<Command, System.Boolean>>(predicate),
-            It.Is<System.Threading.CancellationToken>(cancellationToken)
+            It.Is<global::System.Func<Command, global::System.Boolean>>(predicate),
+            It.Is<global::System.Threading.CancellationToken>(cancellationToken)
           )
         )
         .Throws(exception);

--- a/Sut.Generator.Tests/Snapshots/Verification.Test_index=4#Test4.g.verified.cs
+++ b/Sut.Generator.Tests/Snapshots/Verification.Test_index=4#Test4.g.verified.cs
@@ -14,13 +14,13 @@ public partial class Test4 {
     public Mock<IDependency1> Dependency1 { get; } = new();
 
     public Builder With_Dependency1_Get(
-      System.Linq.Expressions.Expression<System.Func<System.Int32, System.Boolean>> id,
+      global::System.Linq.Expressions.Expression<global::System.Func<global::System.Int32, global::System.Boolean>> id,
       Command returns
     ) {
       Dependency1
         .Setup(x =>
           x.Get(
-            It.Is<System.Int32>(id)
+            It.Is<global::System.Int32>(id)
           )
         )
         .ReturnsAsync(returns)
@@ -29,13 +29,13 @@ public partial class Test4 {
     }
 
     public Builder With_Dependency1_Get_Exception(
-      System.Linq.Expressions.Expression<System.Func<System.Int32, System.Boolean>> id,
-      System.Exception exception
+      global::System.Linq.Expressions.Expression<global::System.Func<global::System.Int32, global::System.Boolean>> id,
+      global::System.Exception exception
     ) {
       Dependency1
         .Setup(x =>
           x.Get(
-            It.Is<System.Int32>(id)
+            It.Is<global::System.Int32>(id)
           )
         )
         .ThrowsAsync(exception);

--- a/Sut.Generator.Tests/Snapshots/Verification.Test_index=5#Test5.g.verified.cs
+++ b/Sut.Generator.Tests/Snapshots/Verification.Test_index=5#Test5.g.verified.cs
@@ -14,7 +14,7 @@ public partial class Test5 {
     public Mock<IDependency2<Command>> Dependency2 { get; } = new();
 
     public Builder<Command> With_Dependency2_Get(
-      System.Collections.Generic.List<Command> returns
+      global::System.Collections.Generic.List<Command> returns
     ) {
       Dependency2
         .Setup(x =>
@@ -26,7 +26,7 @@ public partial class Test5 {
     }
 
     public Builder<Command> With_Dependency2_Get_Exception(
-      System.Exception exception
+      global::System.Exception exception
     ) {
       Dependency2
         .Setup(x =>

--- a/Sut.Generator.Tests/Snapshots/Verification.Test_index=6#Test6.g.verified.cs
+++ b/Sut.Generator.Tests/Snapshots/Verification.Test_index=6#Test6.g.verified.cs
@@ -14,7 +14,7 @@ public partial class Test6 {
     public Mock<IDependency3> Dependency3 { get; } = new();
 
     public Builder With_Dependency3_Run(
-      System.Linq.Expressions.Expression<System.Func<Command, System.Boolean>> command
+      global::System.Linq.Expressions.Expression<global::System.Func<Command, global::System.Boolean>> command
     ) {
       Dependency3
         .Setup(x =>
@@ -27,8 +27,8 @@ public partial class Test6 {
     }
 
     public Builder With_Dependency3_Run_Exception(
-      System.Linq.Expressions.Expression<System.Func<Command, System.Boolean>> command,
-      System.Exception exception
+      global::System.Linq.Expressions.Expression<global::System.Func<Command, global::System.Boolean>> command,
+      global::System.Exception exception
     ) {
       Dependency3
         .Setup(x =>

--- a/Sut.Generator.Tests/Snapshots/Verification.Test_index=7#Test7.g.verified.cs
+++ b/Sut.Generator.Tests/Snapshots/Verification.Test_index=7#Test7.g.verified.cs
@@ -14,7 +14,7 @@ public partial class Test7 {
     public Mock<Dependency5> Dependency5 { get; } = new();
 
     public Builder With_Dependency5_Update<T>(
-      System.Linq.Expressions.Expression<System.Func<T, System.Boolean>> input,
+      global::System.Linq.Expressions.Expression<global::System.Func<T, global::System.Boolean>> input,
       T returns
     ) {
       Dependency5
@@ -29,8 +29,8 @@ public partial class Test7 {
     }
 
     public Builder With_Dependency5_Update_Exception<T>(
-      System.Linq.Expressions.Expression<System.Func<T, System.Boolean>> input,
-      System.Exception exception
+      global::System.Linq.Expressions.Expression<global::System.Func<T, global::System.Boolean>> input,
+      global::System.Exception exception
     ) {
       Dependency5
         .Setup(x =>

--- a/Sut.Generator.Tests/Snapshots/Verification.Test_index=8#Test8.g.verified.cs
+++ b/Sut.Generator.Tests/Snapshots/Verification.Test_index=8#Test8.g.verified.cs
@@ -24,7 +24,7 @@ public partial class Test8 {
     }
 
     public Builder With_Dependency4_Status(
-      System.Action<Dependency4> status
+      global::System.Action<Dependency4> status
     ) {
       Dependency4
         .SetupSet(status)

--- a/Sut.Generator.Tests/Snapshots/Verification.Test_index=9#Test9.g.verified.cs
+++ b/Sut.Generator.Tests/Snapshots/Verification.Test_index=9#Test9.g.verified.cs
@@ -14,15 +14,15 @@ public partial class Test9 {
     public Mock<Dependency6> Dependency6 { get; } = new();
 
     public Builder With_Dependency6_Evaluate(
-      System.Linq.Expressions.Expression<System.Func<System.Func<Command, System.Boolean>, System.Boolean>> predicate,
-      System.Linq.Expressions.Expression<System.Func<System.Threading.CancellationToken, System.Boolean>> cancellationToken,
-      System.Boolean returns
+      global::System.Linq.Expressions.Expression<global::System.Func<global::System.Func<Command, global::System.Boolean>, global::System.Boolean>> predicate,
+      global::System.Linq.Expressions.Expression<global::System.Func<global::System.Threading.CancellationToken, global::System.Boolean>> cancellationToken,
+      global::System.Boolean returns
     ) {
       Dependency6
         .Setup(x =>
           x.Evaluate(
-            It.Is<System.Func<Command, System.Boolean>>(predicate),
-            It.Is<System.Threading.CancellationToken>(cancellationToken)
+            It.Is<global::System.Func<Command, global::System.Boolean>>(predicate),
+            It.Is<global::System.Threading.CancellationToken>(cancellationToken)
           )
         )
         .Returns(returns)
@@ -31,15 +31,15 @@ public partial class Test9 {
     }
 
     public Builder With_Dependency6_Evaluate_Exception(
-      System.Linq.Expressions.Expression<System.Func<System.Func<Command, System.Boolean>, System.Boolean>> predicate,
-      System.Linq.Expressions.Expression<System.Func<System.Threading.CancellationToken, System.Boolean>> cancellationToken,
-      System.Exception exception
+      global::System.Linq.Expressions.Expression<global::System.Func<global::System.Func<Command, global::System.Boolean>, global::System.Boolean>> predicate,
+      global::System.Linq.Expressions.Expression<global::System.Func<global::System.Threading.CancellationToken, global::System.Boolean>> cancellationToken,
+      global::System.Exception exception
     ) {
       Dependency6
         .Setup(x =>
           x.Evaluate(
-            It.Is<System.Func<Command, System.Boolean>>(predicate),
-            It.Is<System.Threading.CancellationToken>(cancellationToken)
+            It.Is<global::System.Func<Command, global::System.Boolean>>(predicate),
+            It.Is<global::System.Threading.CancellationToken>(cancellationToken)
           )
         )
         .Throws(exception);

--- a/Sut.Generator/Extensions.cs
+++ b/Sut.Generator/Extensions.cs
@@ -39,7 +39,7 @@ public static class Extensions
           if (!string.IsNullOrEmpty(sutTypeArgument.TypeArgumentNamespace)
             && sutTypeArgument.TypeArgumentNamespace != sut.Namespace)
           {
-            sb.Append($"{sutTypeArgument.TypeArgumentNamespace}.");
+            sb.Append($"global::{sutTypeArgument.TypeArgumentNamespace}.");
           }
           sb.Append(sutTypeArgument.TypeArgument);
         }
@@ -48,7 +48,7 @@ public static class Extensions
           if (!string.IsNullOrEmpty(typeArgument.TypeArgumentNamespace)
             && typeArgument.TypeArgumentNamespace != sut.Namespace)
           {
-            sb.Append($"{typeArgument.TypeArgumentNamespace}.");
+            sb.Append($"global::{typeArgument.TypeArgumentNamespace}.");
           }
           sb.Append($"{typeArguments[i].TypeArgument}");
         }


### PR DESCRIPTION
Add global:: namespace prefix throughout generated code to avoid namespace collisions.